### PR TITLE
alpha5.1 (fix for tables)

### DIFF
--- a/includes/admin/list-tables/abstract-class-scrm-admin-list-table.php
+++ b/includes/admin/list-tables/abstract-class-scrm-admin-list-table.php
@@ -38,7 +38,10 @@ abstract class SCRM_Admin_List_Table {
         if ( $this->list_table_type ) {
 
             $settings = get_option( str_replace( '_', '_settings_', $this->list_table_type ) );
-        
+            
+            if ( empty( $settings ) )
+                return;
+            
             $ignored = $this->define_ignored_columns();
 
             $this->list_table_columns[ 'image' ] = __( 'Image', 'scrm' );


### PR DESCRIPTION
When start plugin and not save custom-fields for Lead and Contact, in tables send empty array.